### PR TITLE
Replaced json output with python json module, refactored code, added more transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 blender2minecraft
 =================
 
-A Blender Add-on to create Minecraft 3D-Models inside Blender+
+A Blender Add-on to create Minecraft 3D-Models inside Blender.
 
 Feel free to send pull requests. This add-on probably needs a lot of reworking, but I don't have the time to do it.
 (Warning: Code is pretty messy. I had very little python experience when I wrote it)

--- a/blender2minecraft.py
+++ b/blender2minecraft.py
@@ -448,70 +448,32 @@ class ExportBlockModel(Operator, ExportHelper):
         row = layout.row()
         row.prop(self, "ambientocclusion")
 
+        def createTransform(name, value):
+            layout.label()
+            layout.label(text=name)
+            split = layout.split()
+            col = split.column(align=True)
+            col.label(text="Translate:")
+            col.prop(self, value, index=0, text="X")
+            col.prop(self, value, index=1, text="Y")
+            col.prop(self, value, index=2, text="Z")
 
-        layout.label()
-        layout.label(text="First Person:")
-        split = layout.split()
-        col = split.column(align=True)
-        col.label(text="Translate:")
-        col.prop(self, "fpTransform", index=0, text="X")
-        col.prop(self, "fpTransform", index=1, text="Y")
-        col.prop(self, "fpTransform", index=2, text="Z")
+            col = split.column(align=True)
+            col.label(text="Rotate:")
+            col.prop(self, value, index=3, text="X")
+            col.prop(self, value, index=4, text="Y")
+            col.prop(self, value, index=5, text="Z")
 
-        col = split.column(align=True)
-        col.label(text="Rotate:")
-        col.prop(self, "fpTransform", index=0, text="X")
-        col.prop(self, "fpTransform", index=1, text="Y")
-        col.prop(self, "fpTransform", index=2, text="Z")
+            col = split.column(align=True)
+            col.label(text="Scale:")
+            col.prop(self, value, index=6, text="X")
+            col.prop(self, value, index=7, text="Y")
+            col.prop(self, value, index=8, text="Z")
 
-        col = split.column(align=True)
-        col.label(text="Scale:")
-        col.prop(self, "fpTransform", index=0, text="X")
-        col.prop(self, "fpTransform", index=1, text="Y")
-        col.prop(self, "fpTransform", index=2, text="Z")
+        createTransform("First Person:", "fpTransform")
+        createTransform("Third Person:", "tpTransform")
+        createTransform("Inventory:", "guiTransform")
 
-        layout.label()
-        layout.label(text="Third Person:")
-        split = layout.split()
-        col = split.column(align=True)
-        col.label(text="Translate:")
-        col.prop(self, "tpTransform", index=0, text="X")
-        col.prop(self, "tpTransform", index=1, text="Y")
-        col.prop(self, "tpTransform", index=2, text="Z")
-
-        col = split.column(align=True)
-        col.label(text="Rotate:")
-        col.prop(self, "tpTransform", index=0, text="X")
-        col.prop(self, "tpTransform", index=1, text="Y")
-        col.prop(self, "tpTransform", index=2, text="Z")
-
-        col = split.column(align=True)
-        col.label(text="Scale:")
-        col.prop(self, "tpTransform", index=0, text="X")
-        col.prop(self, "tpTransform", index=1, text="Y")
-        col.prop(self, "tpTransform", index=2, text="Z")
-
-
-        layout.label()
-        layout.label(text="Inventory:")
-        split = layout.split()
-        col = split.column(align=True)
-        col.label(text="Translate:")
-        col.prop(self, "guiTransform", index=0, text="X")
-        col.prop(self, "guiTransform", index=1, text="Y")
-        col.prop(self, "guiTransform", index=2, text="Z")
-
-        col = split.column(align=True)
-        col.label(text="Rotate:")
-        col.prop(self, "guiTransform", index=0, text="X")
-        col.prop(self, "guiTransform", index=1, text="Y")
-        col.prop(self, "guiTransform", index=2, text="Z")
-
-        col = split.column(align=True)
-        col.label(text="Scale:")
-        col.prop(self, "guiTransform", index=0, text="X")
-        col.prop(self, "guiTransform", index=1, text="Y")
-        col.prop(self, "guiTransform", index=2, text="Z")
 #        layout.label(text="NOTE: The following options don't work in 14w26b")
 #        layout.label(text="They used to work in 14w21b. Hopefully they get readded.")
 #        row = layout.row()
@@ -528,14 +490,14 @@ class ExportBlockModel(Operator, ExportHelper):
     def execute(self, context):
         return write_to_file(context, self.filepath, self.include_textures, self.ambientocclusion,
                 self.fpTransform[0:3],
-                self.fpTransform[3:6],
                 self.fpTransform[6:9],
+                self.fpTransform[3:6],
                 self.tpTransform[0:3],
-                self.tpTransform[3:6],
                 self.tpTransform[6:9],
+                self.tpTransform[3:6],
                 self.guiTransform[0:3],
-                self.guiTransform[3:6],
-                self.guiTransform[6:9])
+                self.guiTransform[6:9],
+                self.guiTransform[3:6])
 
 
 # Only needed if you want to add into a dynamic menu

--- a/blender2minecraft.py
+++ b/blender2minecraft.py
@@ -210,8 +210,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
 
                         max, min = getMaxMin(uvs, [x, y])
 
-
-
                         if min[x] != max[x] and min[y] != max[y]:
 
                             verts = []
@@ -222,8 +220,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
 
                             print(maxr)
                             print(minr)
-
-
 
                             if direction == "south":
                                 bottom = minr
@@ -311,7 +307,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
 
                             path = imagepath.split(os.sep)
 
-
                             for dir in path:
                                 index = path.index(dir)
                                 if dir == "assets" and path[index+1] == "minecraft" and path[index+2] == "textures":
@@ -324,8 +319,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
                                             filepath += c
                                         else:
                                             break
-
-
 
                             if not [name[0], filepath] in textures:
                                 textures.append([name[0], filepath])
@@ -366,7 +359,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
                                 elif n[0:8] == "particle":
                                     particle = filepath
 
-
                     else:
                         print("Object \"" + data.name + "\" is not a cube!!!")
                 #TODO
@@ -405,7 +397,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, firsttr
     file.write(json.dumps(fileContent))
     file.close()
 
-
     return {'FINISHED'}
 
 
@@ -438,162 +429,10 @@ class ExportBlockModel(Operator, ExportHelper):
             description="Turns the Ambient Occlusion option on or off",
             default=True,
             )
-    firsttransx = FloatProperty(
-            name="X",
-            description="Moves the Object in firstperson on the X axis",
-            default=0.0,
-            )
-    firsttransy = FloatProperty(
-            name="Y",
-            description="Moves the Object in firstperson on the Y axis",
-            default=0.0,
-            )
-    firsttransz = FloatProperty(
-            name="Z",
-            description="Moves the Object in firstperson on the Z axis",
-            default=0.0,
-            )
-    firstrotx = FloatProperty(
-            name="X",
-            description="Rotates the Object in firstperson on the X axis",
-            default=0.0,
-            )
-    firstroty = FloatProperty(
-            name="Y",
-            description="Rotates the Object in firstperson on the Y axis",
-            default=0.0,
-            )
-    firstrotz = FloatProperty(
-            name="Z",
-            description="Rotates the Object in firstperson on the Z axis",
-            default=0.0,
-            )
-    firstscalex = FloatProperty(
-            name="X",
-            description="Scales the Object in firstperson on the X axis",
-            default=1.0,
-            )
-    firstscaley = FloatProperty(
-            name="Y",
-            description="Scales the Object in firstperson on the Y axis",
-            default=1.0,
-            )
-    firstscalez = FloatProperty(
-            name="Z",
-            description="Scales the Object in firstperson on the Z axis",
-            default=1.0,
-            )
-    thirdtransx = FloatProperty(
-            name="X",
-            description="Moves the Object in thirdperson on the X axis",
-            default=0.0,
-            )
-    thirdtransy = FloatProperty(
-            name="Y",
-            description="Moves the Object in thirdperson on the Y axis",
-            default=0.0,
-            )
-    thirdtransz = FloatProperty(
-            name="Z",
-            description="Moves the Object in thirdperson on the Z axis",
-            default=0.0,
-            )
-    thirdrotx = FloatProperty(
-            name="X",
-            description="Rotates the Object in thirdperson on the X axis",
-            default=0.0,
-            )
-    thirdroty = FloatProperty(
-            name="Y",
-            description="Rotates the Object in thirdperson on the Y axis",
-            default=0.0,
-            )
-    thirdrotz = FloatProperty(
-            name="Z",
-            description="Rotates the Object in thirdperson on the Z axis",
-            default=0.0,
-            )
-    thirdscalex = FloatProperty(
-            name="X",
-            description="Scales the Object in thirdperson on the X axis",
-            default=1.0,
-            )
-    thirdscaley = FloatProperty(
-            name="Y",
-            description="Scales the Object in thirdperson on the Y axis",
-            default=1.0,
-            )
-    thirdscalez = FloatProperty(
-            name="Z",
-            description="Scales the Object in thirdperson on the Z axis",
-            default=1.0,
-            )
 
-    invtransx = FloatProperty(
-            name="X",
-            description="Moves the Object in the Inventory on the X axis",
-            default=0.0,
-            )
-    invtransy = FloatProperty(
-            name="Y",
-            description="Moves the Object in the Inventory on the Y axis",
-            default=0.0,
-            )
-    invtransz = FloatProperty(
-            name="Z",
-            description="Moves the Object in the Inventory on the Z axis",
-            default=0.0,
-            )
-    invrotx = FloatProperty(
-            name="X",
-            description="Rotates the Object in the Inventory on the X axis",
-            default=0.0,
-            )
-    invroty = FloatProperty(
-            name="Y",
-            description="Rotates the Object in the Inventory on the Y axis",
-            default=0.0,
-            )
-    invrotz = FloatProperty(
-            name="Z",
-            description="Rotates the Object in the Inventory on the Z axis",
-            default=0.0,
-            )
-    invscalex = FloatProperty(
-            name="X",
-            description="Scales the Object in the Inventory on the X axis",
-            default=1.0,
-            )
-    invscaley = FloatProperty(
-            name="Y",
-            description="Scales the Object in the Inventory on the Y axis",
-            default=1.0,
-            )
-    invscalez = FloatProperty(
-            name="Z",
-            description="Scales the Object in the Inventory on the Z axis",
-            default=1.0,
-            )
-#    randomoffset_x = BoolProperty(
-#            name="X",
-#            description="Use Random Offset on the X Axis",
-#            default=False,
-#            )
-#    randomoffset_y = BoolProperty(
-#            name="Y",
-#            description="Use Random Offset on the X Axis",
-#            default=False,
-#            )
-#    randomoffset_z = BoolProperty(
-#            name="Z",
-#            description="Use Random Offset on the X Axis",
-#            default=False,
-#            )
-#    inverntory3drender = BoolProperty(
-#            name="Inventory 3D Rendering",
-#            description="Renders the Block 3D inside an inventory",
-#            default=True,
-#            )
+    fpTransform = bpy.props.FloatVectorProperty(name = "First Person Transform", description = "Translation, Rotation and Scale of first person (in hand) rendering", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    tpTransform = bpy.props.FloatVectorProperty(name = "Third Person Transform", description = "Translation, Rotation and Scale of third person rendering", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    guiTransform = bpy.props.FloatVectorProperty(name = "GUI Transform", description = "Translation, Rotation and Scale in the GUI (Inventory)", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
 
     def draw(self, context):
         layout = self.layout
@@ -615,42 +454,42 @@ class ExportBlockModel(Operator, ExportHelper):
         split = layout.split()
         col = split.column(align=True)
         col.label(text="Translate:")
-        col.prop(self, "firsttransx")
-        col.prop(self, "firsttransy")
-        col.prop(self, "firsttransz")
+        col.prop(self, "fpTransform", index=0, text="X")
+        col.prop(self, "fpTransform", index=1, text="Y")
+        col.prop(self, "fpTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Rotate:")
-        col.prop(self, "firstrotx")
-        col.prop(self, "firstroty")
-        col.prop(self, "firstrotz")
+        col.prop(self, "fpTransform", index=0, text="X")
+        col.prop(self, "fpTransform", index=1, text="Y")
+        col.prop(self, "fpTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Scale:")
-        col.prop(self, "firstscalex")
-        col.prop(self, "firstscaley")
-        col.prop(self, "firstscalez")
+        col.prop(self, "fpTransform", index=0, text="X")
+        col.prop(self, "fpTransform", index=1, text="Y")
+        col.prop(self, "fpTransform", index=2, text="Z")
 
         layout.label()
         layout.label(text="Third Person:")
         split = layout.split()
         col = split.column(align=True)
         col.label(text="Translate:")
-        col.prop(self, "thirdtransx")
-        col.prop(self, "thirdtransy")
-        col.prop(self, "thirdtransz")
+        col.prop(self, "tpTransform", index=0, text="X")
+        col.prop(self, "tpTransform", index=1, text="Y")
+        col.prop(self, "tpTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Rotate:")
-        col.prop(self, "thirdrotx")
-        col.prop(self, "thirdroty")
-        col.prop(self, "thirdrotz")
+        col.prop(self, "tpTransform", index=0, text="X")
+        col.prop(self, "tpTransform", index=1, text="Y")
+        col.prop(self, "tpTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Scale:")
-        col.prop(self, "thirdscalex")
-        col.prop(self, "thirdscaley")
-        col.prop(self, "thirdscalez")
+        col.prop(self, "tpTransform", index=0, text="X")
+        col.prop(self, "tpTransform", index=1, text="Y")
+        col.prop(self, "tpTransform", index=2, text="Z")
 
 
         layout.label()
@@ -658,21 +497,21 @@ class ExportBlockModel(Operator, ExportHelper):
         split = layout.split()
         col = split.column(align=True)
         col.label(text="Translate:")
-        col.prop(self, "invtransx")
-        col.prop(self, "invtransy")
-        col.prop(self, "invtransz")
+        col.prop(self, "guiTransform", index=0, text="X")
+        col.prop(self, "guiTransform", index=1, text="Y")
+        col.prop(self, "guiTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Rotate:")
-        col.prop(self, "invrotx")
-        col.prop(self, "invroty")
-        col.prop(self, "invrotz")
+        col.prop(self, "guiTransform", index=0, text="X")
+        col.prop(self, "guiTransform", index=1, text="Y")
+        col.prop(self, "guiTransform", index=2, text="Z")
 
         col = split.column(align=True)
         col.label(text="Scale:")
-        col.prop(self, "invscalex")
-        col.prop(self, "invscaley")
-        col.prop(self, "invscalez")
+        col.prop(self, "guiTransform", index=0, text="X")
+        col.prop(self, "guiTransform", index=1, text="Y")
+        col.prop(self, "guiTransform", index=2, text="Z")
 #        layout.label(text="NOTE: The following options don't work in 14w26b")
 #        layout.label(text="They used to work in 14w21b. Hopefully they get readded.")
 #        row = layout.row()
@@ -688,15 +527,15 @@ class ExportBlockModel(Operator, ExportHelper):
 
     def execute(self, context):
         return write_to_file(context, self.filepath, self.include_textures, self.ambientocclusion,
-                [self.firsttransx, self.firsttransy, self.firsttransz],
-                [self.firstscalex, self.firstscaley, self.firstscalez],
-                [self.firstrotx, self.firstroty, self.firstrotz],
-                [self.thirdtransx, self.thirdtransy, self.thirdtransz],
-                [self.thirdscalex, self.thirdscaley, self.thirdscalez],
-                [self.thirdrotx, self.thirdroty, self.thirdrotz],
-                [self.invtransx, self.invtransy, self.invtransz],
-                [self.invscalex, self.invscaley, self.invscalez],
-                [self.invrotx, self.invroty, self.invrotz])
+                self.fpTransform[0:3],
+                self.fpTransform[3:6],
+                self.fpTransform[6:9],
+                self.tpTransform[0:3],
+                self.tpTransform[3:6],
+                self.tpTransform[6:9],
+                self.guiTransform[0:3],
+                self.guiTransform[3:6],
+                self.guiTransform[6:9])
 
 
 # Only needed if you want to add into a dynamic menu

--- a/blender2minecraft.py
+++ b/blender2minecraft.py
@@ -1,8 +1,8 @@
 bl_info = {
     "name": "Blender2Minecraft",
     "author": "freundTech",
-    "version": (0, 1),
-    "blender": (2, 7, 9),
+    "version": (0, 2),
+    "blender": (2, 6, 9),
     "location": "File > Export > Export to Minecraft",
     "description": "Export Scene as Minecraft Blockmodel",
     "wiki_url": "https://github.com/freundTech/blender2minecraft/wiki",

--- a/blender2minecraft.py
+++ b/blender2minecraft.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Blender2Minecraft",
     "author": "freundTech",
     "version": (0, 1),
-    "blender": (2, 6, 9),
+    "blender": (2, 7, 9),
     "location": "File > Export > Export to Minecraft",
     "description": "Export Scene as Minecraft Blockmodel",
     "wiki_url": "https://github.com/freundTech/blender2minecraft/wiki",
@@ -10,7 +10,6 @@ bl_info = {
     "support": "COMMUNITY",
     "category": "Import-Export"
 }
-
 
 import bpy
 from bpy import context
@@ -24,7 +23,6 @@ y = 1
 z = 2
 
 toRound = 2
-
 
 def getMaxMin(values, use):
     max = [None]*len(use)
@@ -99,7 +97,13 @@ class attrdict(dict):
         dict.__init__(self, *args, **kwargs)
         self.__dict__ = self
 
-def write_to_file(context, filepath, include_textures, ambientocclusion, minify, firsttrans, firstscale, firstrot, thirdtrans, thirdscale, thirdrot, invtrans, invscale, invrot):
+def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
+                firsttrans, firstscale, firstrot,
+                thirdtrans, thirdscale, thirdrot,
+                invtrans, invscale, invrot,
+                headtrans, headscale, headrot,
+                groundtrans, groundscale, groundrot,
+                fixedtrans, fixedscale, fixedrot):
     textures = []
     particle = ""
     scene = context.scene
@@ -133,7 +137,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
                 pos = obj.location
                 scale = obj.scale
                 #print(str(obj.bound_box[0][:]) + " " + str(obj.bound_box[1][:]) + " " + str(obj.bound_box[2][:]) + str(obj.bound_box[3][:]) + " " + str(obj.bound_box[4][:]) + " " + str(obj.bound_box[5][:]) + " " + str(obj.bound_box[6][:]) + " " + str(obj.bound_box[7][:]) + " ")
-
 
                 for co in box:
                     for i in range(0, 3):
@@ -193,7 +196,6 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
                                 item["rotation"]["rescale"] = n[8:].lower() == "true"
                     else:
                         raise Exception("You can only rotate by 22.5, -22.5, 45 or -45 degrees!")
-
 
                 item["faces"] = {}
 
@@ -391,6 +393,21 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
             "rotation": [rval(invrot[x]), rval(invrot[y]), rval(invrot[z])],
             "translation": [rval(invtrans[x]), rval(invtrans[y]), rval(invtrans[z])],
             "scale": [rval(invscale[x]), rval(invscale[y]), rval(invscale[z])]
+        },
+        "head": {
+            "rotation": [rval(headrot[x]), rval(headrot[y]), rval(headrot[z])],
+            "translation": [rval(headtrans[x]), rval(headtrans[y]), rval(headtrans[z])],
+            "scale": [rval(headscale[x]), rval(headscale[y]), rval(headscale[z])]
+        },
+        "ground": {
+            "rotation": [rval(groundrot[x]), rval(groundrot[y]), rval(groundrot[z])],
+            "translation": [rval(groundtrans[x]), rval(groundtrans[y]), rval(groundtrans[z])],
+            "scale": [rval(groundscale[x]), rval(groundscale[y]), rval(groundscale[z])]
+        },
+        "fixed": {
+            "rotation": [rval(fixedrot[x]), rval(fixedrot[y]), rval(fixedrot[z])],
+            "translation": [rval(fixedtrans[x]), rval(fixedtrans[y]), rval(fixedtrans[z])],
+            "scale": [rval(fixedscale[x]), rval(fixedscale[y]), rval(fixedscale[z])]
         }
     }
 
@@ -403,13 +420,11 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
 
     return {'FINISHED'}
 
-
 # ExportHelper is a helper class, defines filename and
 # invoke() function which calls the file selector.
 from bpy_extras.io_utils import ExportHelper
 from bpy.props import StringProperty, BoolProperty, EnumProperty, FloatProperty
 from bpy.types import Operator
-
 
 class ExportBlockModel(Operator, ExportHelper):
     """This appears in the tooltip of the operator and in the generated docs"""
@@ -442,6 +457,9 @@ class ExportBlockModel(Operator, ExportHelper):
     fpTransform = bpy.props.FloatVectorProperty(name = "First Person Transform", description = "Translation, Rotation and Scale of first person (in hand) rendering", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
     tpTransform = bpy.props.FloatVectorProperty(name = "Third Person Transform", description = "Translation, Rotation and Scale of third person rendering", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
     guiTransform = bpy.props.FloatVectorProperty(name = "GUI Transform", description = "Translation, Rotation and Scale in the GUI (Inventory)", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    headTransform = bpy.props.FloatVectorProperty(name = "Head Transform", description = "Translation, Rotation and Scale when equipped as helmet", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    groundTransform = bpy.props.FloatVectorProperty(name = "Ground Transform", description = "Translation, Rotation and Scale on the ground", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    fixedTransform = bpy.props.FloatVectorProperty(name = "Item Frame Transform", description = "Translation, Rotation and Scale in Item Frames", size = 9, default=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
 
     def draw(self, context):
         layout = self.layout
@@ -486,6 +504,9 @@ class ExportBlockModel(Operator, ExportHelper):
         createTransform("First Person:", "fpTransform")
         createTransform("Third Person:", "tpTransform")
         createTransform("Inventory:", "guiTransform")
+        createTransform("Head:", "headTransform")
+        createTransform("Ground:", "groundTransform")
+        createTransform("Item Frame:", "fixedTransform")
 
 #        layout.label(text="NOTE: The following options don't work in 14w26b")
 #        layout.label(text="They used to work in 14w21b. Hopefully they get readded.")
@@ -510,23 +531,28 @@ class ExportBlockModel(Operator, ExportHelper):
                 self.tpTransform[3:6],
                 self.guiTransform[0:3],
                 self.guiTransform[6:9],
-                self.guiTransform[3:6])
-
+                self.guiTransform[3:6],
+                self.headTransform[0:3],
+                self.headTransform[6:9],
+                self.headTransform[3:6],
+                self.groundTransform[0:3],
+                self.groundTransform[6:9],
+                self.groundTransform[3:6],
+                self.fixedTransform[0:3],
+                self.fixedTransform[6:9],
+                self.fixedTransform[3:6])
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_export(self, context):
     self.layout.operator(ExportBlockModel.bl_idname, text="Minecraft model (.json)")
 
-
 def register():
     bpy.utils.register_class(ExportBlockModel)
     bpy.types.INFO_MT_file_export.append(menu_func_export)
 
-
 def unregister():
     bpy.utils.unregister_class(ExportBlockModel)
     bpy.types.INFO_MT_file_export.remove(menu_func_export)
-
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
Instead of writing every json line as static strings it now just writes a python object (like `{"a": 5, "b": [1, 2, 3]}`)

This is much more failsafe and allows more configuration. Right now I have added a boolean [x] Minify Json. File size drops by about 30%-40% if minify is on.

Also setting translation, rotation and scale is now possible for head, ground and fixed (item frame)

Line numbers reduced from 743 to 562 due to optimization, replacing more than 2 line breaks with only 2 line breaks, refactoring and changing the json output with python json.