### PR TITLE
Fix: Missing texture filepath if path doesn't contain minecraft assets folder

### DIFF
--- a/blender2minecraft/export.py
+++ b/blender2minecraft/export.py
@@ -286,15 +286,17 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
                             filepath = ""
                             if image.filepath == "":
                                 print("Warning: Image %s not saved to disk. Can't get path!" % image.name)
-                            imagepath = bpy.path.abspath(image.filepath)
-                            imagepath = os.path.abspath(imagepath)
+                            else:
+                                filepath = image.filepath
+                                
+                                imagepath = bpy.path.abspath(image.filepath)
+                                imagepath = os.path.abspath(imagepath)
+                                path = imagepath.split(os.sep)
+                                for i, dir in enumerate(path):
+                                    if dir == "assets" and path[i+1] == "minecraft" and path[i+2] == "textures":
+                                        filepath = os.path.join(*path[i+3:])
 
-                            path = imagepath.split(os.sep)
-
-                            for i, dir in enumerate(path):
-                                if dir == "assets" and path[i+1] == "minecraft" and path[i+2] == "textures":
-                                    filepath = os.path.join(*path[i+3:])
-                                    filepath = os.path.splitext(filepath)[0]
+                                filepath = os.path.splitext(filepath)[0]
 
                             if not [image.name, filepath] in textures:
                                 textures.append([image.name, filepath])

--- a/blender2minecraft/export.py
+++ b/blender2minecraft/export.py
@@ -287,7 +287,7 @@ def write_to_file(context, filepath, include_textures, ambientocclusion, minify,
                             if image.filepath == "":
                                 print("Warning: Image %s not saved to disk. Can't get path!" % image.name)
                             else:
-                                filepath = image.filepath
+                                filepath = bpy.path.relpath(image.filepath)
                                 
                                 imagepath = bpy.path.abspath(image.filepath)
                                 imagepath = os.path.abspath(imagepath)


### PR DESCRIPTION
If the path to the texture file doesn't contain 'assets/minecraft/textures/', it currently doesn't set the filepath of the texture.

This pull request aims to fix that.